### PR TITLE
Correct uint64ToString for plain Decimal numbers

### DIFF
--- a/transmitter/transmitter.ino
+++ b/transmitter/transmitter.ino
@@ -1053,13 +1053,16 @@ uint64_t generateAddress()
 
 String uint64ToString(uint64_t number)
 {
-	unsigned long part1 = (unsigned long)((number >> 32)); // Bitwise Right Shift
-	unsigned long part2 = (unsigned long)((number));
-
-	if(part1 == 0){
-	  return String(part2, DEC);
-	}
-	return String(part1, DEC) + String(part2, DEC);
+	String result = "";
+  	uint8_t base = 10;
+	
+	do {
+		char c = (input % base) + '0';
+		input /= base;
+		result += c;
+	} while (input);
+	
+  	return result;
 }
 
 String uint64ToAddress(uint64_t number)


### PR DESCRIPTION
previously, it was doing bit shift operation, and then truncated the string.
but since the values given to this function won't go over 4 billion for sure, this won't make any difference really :(